### PR TITLE
docs: fix README to show correct generated sources path

### DIFF
--- a/customer-service-client/README.md
+++ b/customer-service-client/README.md
@@ -45,7 +45,7 @@ mvn clean install
 Generated sources will be placed under:
 
 ```
-target/generated-sources/openapi/src/gen/java/main
+target/generated-sources/openapi/src/gen/java
 ```
 
 ---


### PR DESCRIPTION
- Updated README.md to use `src/gen/java` instead of outdated `src/gen/java/main`
- Keeps documentation consistent with latest client generation setup